### PR TITLE
Add support of the Windows SDK 26100 stable + links update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install the Windows SDK 26100
         uses: ./
         with:
-          version-sdk: 26100
+          version-sdk: 22621
           features: "OptionId.UWPCPP, OptionId.DesktopCPPx64, OptionId.DesktopCPPx86, OptionId.DesktopCPParm64, OptionId.DesktopCPParm"
 
   test-insider-install:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: Install the Windows SDK 26100
+      - name: Install the Windows SDK 22621
         uses: ./
         with:
           version-sdk: 22621

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
 
-      - name: Install the Windows SDK 22621
+      - name: Install the Windows SDK 26100
         uses: ./
         with:
-          version-sdk: 22621
+          version-sdk: 26100
           features: "OptionId.UWPCPP, OptionId.DesktopCPPx64, OptionId.DesktopCPPx86, OptionId.DesktopCPParm64, OptionId.DesktopCPParm"
 
   test-insider-install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.2
+
+- Added support of Windows SDK 26100 stable 
+- Updated download links of the stable Windows SDK versions
+
 ## v1.0.1
 
 - Added support of stable Windows SDK versions

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The available features of the Windows 10/11 SDK are:
 ```yaml
 - uses: ChristopheLav/windows-sdk-install@v1
   with:
-    version-sdk: 22621
+    version-sdk: 26100
     features: 'OptionId.UWPCPP,OptionId.DesktopCPParm64'
 ```
 <!-- end usage -->

--- a/scripts/Install-WindowsSdkISO.ps1
+++ b/scripts/Install-WindowsSdkISO.ps1
@@ -301,12 +301,13 @@ if ($InstallWindowsSDK)
         15063 { throw "The Windows SDK $buildNumber is not available in ISO format. Can't be installed." }
         16299 { throw "The Windows SDK $buildNumber is not available in ISO format. Can't be installed." }
         17134 { throw "The Windows SDK $buildNumber is not available in ISO format. Can't be installed." }
-        17763 { $uri = "https://software-download.microsoft.com/download/sg/17763.132.181022-1834.rs5_release_svc_prod1_WindowsSDK.iso" }
-        18362 { $uri = "https://software-download.microsoft.com/download/sg/18362.1.190318-1202.19h1_release_WindowsSDK.iso" }
-        19041 { $uri = "https://software-download.microsoft.com/download/sg/19041.685.201201-2105.vb_release_svc_prod1_WindowsSDK.iso" }
-        20348 { $uri = "https://software-download.microsoft.com/download/sg/20348.1.210507-1500.fe_release_WindowsSDK.iso" }
-        22000 { $uri = "https://software-static.download.prss.microsoft.com/dbazure/888969d5-f34g-4e03-ac9d-1f9786c66750/22000.832.220715-1440.co_release_svc_prod3_WindowsSDK.iso" }
-        22621 { $uri = "https://software-static.download.prss.microsoft.com/dbazure/988969d5-f34g-4e03-ac9d-1f9786c66756/22621.755.221019-1136.ni_release_svc_prod3_WindowsSDK.iso" }
+        17763 { $uri = "https://go.microsoft.com/fwlink/p/?LinkID=2033686" }
+        18362 { $uri = "https://go.microsoft.com/fwlink/?linkid=2083448" }
+        19041 { $uri = "https://go.microsoft.com/fwlink/?linkid=2120735" }
+        20348 { $uri = "https://go.microsoft.com/fwlink/?linkid=2164360" }
+        22000 { $uri = "https://go.microsoft.com/fwlink/?linkid=2173746" }
+        22621 { $uri = "https://go.microsoft.com/fwlink/?linkid=2249825" }
+        26100 { $uri = "https://go.microsoft.com/fwlink/?linkid=2286663" }
         default { $uri = "https://software-download.microsoft.com/download/sg/Windows_InsiderPreview_SDK_en-us_$($buildNumber)_1.iso" }
     }
 


### PR DESCRIPTION
This pull request includes updates to support the Windows SDK 26100 stable version and updates download links for several Windows SDK versions. The most important changes include updating the changelog, modifying the README to reflect the new SDK version, and updating the PowerShell script to include the new download links.

Updates to support Windows SDK 26100:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Added a new entry for version 1.0.2, which includes support for Windows SDK 26100 stable and updated download links for stable Windows SDK versions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45): Updated the SDK version in the usage example from 22621 to 26100.

Updated download links for Windows SDK versions:

* [`scripts/Install-WindowsSdkISO.ps1`](diffhunk://#diff-c15a792be369f870772463efbe24f9d844f1ea753fb1888abbaeeba4d468e60cL304-R310): Updated the download links for Windows SDK versions 17763, 18362, 19041, 20348, 22000, and 22621 to use new URLs, and added a new link for version 26100.