### PR TITLE
Detect failed Windows SDK installation and throw an error with the installation log path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.3
+
+- Added a validation to ensure the Windows SDK was properly installed, otherwise throw an error with the log file path for more details
+- Updated the inputs in the README to indicate that the option `OptionId.DesktopCPParm` is no more available in the Windows SDK 26100 and beyound
+
 ## v1.0.2
 
 - Added support of Windows SDK 26100 stable 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The available features of the Windows 10/11 SDK are:
 - OptionId.UWPLocalized
 - OptionId.DesktopCPPx86
 - OptionId.DesktopCPPx64
-- OptionId.DesktopCPParm
+- OptionId.DesktopCPParm **(no more exists in SDK 26100 and beyound)**
 - OptionId.DesktopCPParm64
 
 ## Usage

--- a/scripts/Install-WindowsSdkISO.ps1
+++ b/scripts/Install-WindowsSdkISO.ps1
@@ -353,8 +353,15 @@ if ($InstallWindowsSDK)
             Write-Host -NoNewLine "Installing WinSDK..."
 
             $setupPath = Join-Path "$isoDrive" "WinSDKSetup.exe"
-            Start-Process -Wait $setupPath "/features $WindowsSDKOptions /q"
+            $setupLog = Join-Path $winsdkTempDir "WinSDKSetup_$buildNumber.log"
+            Start-Process -Wait $setupPath "/features $WindowsSDKOptions /l $setupLog /q"
             Write-Host "Done"
+
+            # Validate if the SDK was properly installed
+            if (Test-InstallWindowsSDK)
+            {
+                throw "Windows SDK $WindowsSDKVersion was not properly installed. See $setupLog for details."
+            }
         }
         else
         {


### PR DESCRIPTION
This pull request includes several updates related to the Windows SDK installation and documentation. The most important changes add validation to ensure the SDK is installed correctly and update the documentation to reflect changes in the available options.

### Validation and Error Handling:

* [`scripts/Install-WindowsSdkISO.ps1`](diffhunk://#diff-c15a792be369f870772463efbe24f9d844f1ea753fb1888abbaeeba4d468e60cL356-R364): Added a validation step to ensure the Windows SDK is properly installed, throwing an error with the log file path if the installation fails.

### Documentation Updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7): Added a new entry for version 1.0.3, detailing the added validation and updates to the README regarding the deprecated `OptionId.DesktopCPParm` in Windows SDK 26100 and beyond.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L36-R36): Updated the list of available features to indicate that `OptionId.DesktopCPParm` is no longer available in SDK 26100 and beyond.